### PR TITLE
FIX: instance is not defined (ad4eaaf43f644db983a365f0375777f1fb1e26f9)

### DIFF
--- a/open_graph.py
+++ b/open_graph.py
@@ -56,13 +56,13 @@ def open_graph_tag(item):
     if image:
         ogtags.append(('og:image', image))
     else:
-        soup = BeautifulSoup(instance._content, 'html.parser')
+        soup = BeautifulSoup(item._content, 'html.parser')
         img_links = soup.find_all('img')
         if  (len(img_links) > 0):
             img_src = img_links[0].get('src')
             if not "http" in img_src:
-                if instance.settings.get('SITEURL', ''):
-                    img_src = instance.settings.get('SITEURL', '') + "/" + img_src
+                if item.settings.get('SITEURL', ''):
+                    img_src = item.settings.get('SITEURL', '') + "/" + img_src
             ogtags.append(('og:image', img_src))
 
     url = os.path.join(item.settings.get('SITEURL', ''), item.url)


### PR DESCRIPTION
This fixes the error introduced in ad4eaaf43f644db983a365f0375777f1fb1e26f9: Instead of `instance` `item` should be used.